### PR TITLE
Refactor `web_server/api_gateway` to fix circular import

### DIFF
--- a/web_server/api_gateway/__init__.py
+++ b/web_server/api_gateway/__init__.py
@@ -1,12 +1,8 @@
-
 """
 API Gateway Module for AI Backlog Assistant
 """
 
-from flask import Blueprint
-
-# Create API Gateway Blueprint
-api_gateway_bp = Blueprint('api_gateway', __name__)
+from .gateway import api_gateway_bp
 
 # Import routes to register them with the blueprint
 from . import auth_routes

--- a/web_server/api_gateway/analysis_routes.py
+++ b/web_server/api_gateway/analysis_routes.py
@@ -7,7 +7,7 @@ Analysis Routes for API Gateway
 
 import json
 from flask import request, jsonify, current_app
-from . import api_gateway_bp
+from .gateway import api_gateway_bp
 from .auth_middleware import token_required
 from ..app import db
 from web_server.models import Document, DocumentAnalysis

--- a/web_server/api_gateway/auth_routes.py
+++ b/web_server/api_gateway/auth_routes.py
@@ -6,7 +6,7 @@ Authentication Routes for API Gateway
 """
 
 from flask import request, jsonify
-from . import api_gateway_bp
+from .gateway import api_gateway_bp
 from .auth_middleware import generate_token, token_required
 from werkzeug.security import check_password_hash
 from ..app import db

--- a/web_server/api_gateway/document_routes.py
+++ b/web_server/api_gateway/document_routes.py
@@ -10,7 +10,7 @@ import os
 import tempfile
 import json
 from flask import request, jsonify, current_app
-from . import api_gateway_bp
+from .gateway import api_gateway_bp
 from .auth_middleware import token_required
 from ..app import db
 from web_server.models import Document, DocumentAnalysis

--- a/web_server/api_gateway/gateway.py
+++ b/web_server/api_gateway/gateway.py
@@ -1,0 +1,8 @@
+"""
+API Gateway Blueprint
+"""
+
+from flask import Blueprint
+
+# Create API Gateway Blueprint
+api_gateway_bp = Blueprint('api_gateway', __name__)

--- a/web_server/api_gateway/organization_routes.py
+++ b/web_server/api_gateway/organization_routes.py
@@ -6,7 +6,7 @@ Organization Management Routes for API Gateway
 
 import uuid
 from flask import request, jsonify, current_app
-from . import api_gateway_bp
+from .gateway import api_gateway_bp
 from .auth_middleware import token_required
 from ..app import db
 from ..models import Organization, OrganizationMember, User, Document, DocumentAnalysis

--- a/web_server/api_gateway/user_routes.py
+++ b/web_server/api_gateway/user_routes.py
@@ -9,7 +9,7 @@ User Management Routes for API Gateway
 
 import uuid
 from flask import request, jsonify, current_app
-from . import api_gateway_bp
+from .gateway import api_gateway_bp
 from .auth_middleware import token_required, generate_token
 from ..app import db
 from ..models import User, Organization, OrganizationMember, Document, DocumentAnalysis


### PR DESCRIPTION
A circular import was detected in the `web_server/api_gateway` module. The `__init__.py` file was importing route modules, which were in turn importing a Blueprint object from the `__init__.py` file.

This change resolves the issue by creating a new `gateway.py` file to hold the Blueprint definition. The `__init__.py` and all route files have been updated to import the Blueprint from this new file, breaking the circular dependency.